### PR TITLE
WIP: Add event-driven fixed-point algorithms (PEF and WPEF)

### DIFF
--- a/include/barebones_dive_and_solve.hpp
+++ b/include/barebones_dive_and_solve.hpp
@@ -6,6 +6,9 @@
 #include "common_solving.hpp"
 #include "memory_gpu.hpp"
 #include "lala/light_branch.hpp"
+#include "lala/wac3_fixpoint.hpp"
+#include "lala/wwac3_fixpoint.hpp"
+#include "lala/awwac3_fixpoint.hpp"
 #include <mutex>
 #include <thread>
 #include <chrono>
@@ -66,14 +69,152 @@ struct UnifiedData {
   /** The memory configuration of each block. */
   MemoryConfig mem_config;
 
+  /** Variable -> incident-bytecode CSR adjacency.
+   *
+   * Used by the WAC3 (event-driven AC3 worklist) fixpoint strategy: when a
+   * variable is narrowed, only the bytecodes incident to it need to be
+   * re-examined. This adjacency is invariant across the entire search tree
+   * (the constraint network is fixed after preprocess), so it is built ONCE
+   * here and read concurrently by every block.
+   *
+   *   `wac3_adj_off`: CSR offsets, size `num_vars + 1`.
+   *   `wac3_adj_bc`:  flat list of incident bytecode indices, size
+   *                   `3 * num_bytecodes` (each ternary bytecode contributes
+   *                   to 3 variable buckets).
+   *
+   * Empty when the configured fixpoint strategy is not WAC3 — building it is
+   * O(num_bytecodes) on the host but it does cost `(num_vars + 1 + 3 * num_bc)`
+   * ints of managed memory, which is non-trivial for very large networks.
+   * Step 4 (the WAC3 kernel) reads these via grid_data.
+   */
+  bt::vector<int, ConcurrentAllocator> wac3_adj_off;
+  bt::vector<int, ConcurrentAllocator> wac3_adj_bc;
+
+  /** Variable -> incident-TILE CSR adjacency, used by the WWAC3 (warp-tile
+   * AC3 worklist) fixpoint strategy. A tile is 32 consecutive bytecodes; a var
+   * is in tile `t`'s scope if any of `t`'s bytecodes reference it (deduped per
+   * tile). When a var narrows, only its incident TILES are re-enqueued.
+   * Empty unless the configured fixpoint is WWAC3. */
+  bt::vector<int, ConcurrentAllocator> wwac3_vt_off;
+  bt::vector<int, ConcurrentAllocator> wwac3_vt;
+
   UnifiedData(const CP<Itv>& cp, MemoryConfig mem_config)
    : root(GridCP::tag_gpu_block_copy{}, false, cp)
    , stop(false)
    , mem_config(mem_config)
+   , wac3_adj_off(ConcurrentAllocator{})
+   , wac3_adj_bc(ConcurrentAllocator{})
+   , wwac3_vt_off(ConcurrentAllocator{})
+   , wwac3_vt(ConcurrentAllocator{})
   {
     size_t num_subproblems = 1;
     num_subproblems <<= root.config.subproblems_power;
     root.stats.eps_num_subproblems = num_subproblems;
+    if(root.config.fixpoint == FixpointKind::WAC3) {
+      build_wac3_adjacency();
+    }
+    else if(root.config.fixpoint == FixpointKind::WWAC3
+         || root.config.fixpoint == FixpointKind::AWWAC3) {
+      build_wwac3_adjacency();  // var->TILE CSR shared by WWAC3 + async AWWAC3.
+    }
+  }
+
+private:
+  /** Build the variable -> incident-bytecode CSR.
+   *
+   * Two-pass: first pass tallies degree per variable, second pass scatters
+   * incidence. Bytecodes are ternary (x, y, z), so each bytecode contributes
+   * to exactly 3 variable buckets. A variable can appear multiple times in
+   * the same bytecode (e.g. `x = y + y`); we tolerate duplicates here — the
+   * WAC3 kernel's `in_next[]` dedup flag prevents redundant re-enqueueing
+   * during propagation, so the cost is at most a few extra adjacency entries.
+   */
+  void build_wac3_adjacency() {
+    const int num_vars = root.store->vars();
+    const int num_bc   = root.iprop->num_deductions();
+    wac3_adj_off.resize(num_vars + 1);
+    wac3_adj_bc.resize(static_cast<size_t>(3) * num_bc);
+    for(int v = 0; v <= num_vars; ++v) wac3_adj_off[v] = 0;
+    // Pass 1: degree count (stored shifted by 1 to ease the prefix-sum).
+    for(int i = 0; i < num_bc; ++i) {
+      auto bc = root.iprop->load_deduce(i);
+      ++wac3_adj_off[bc.x.vid() + 1];
+      ++wac3_adj_off[bc.y.vid() + 1];
+      ++wac3_adj_off[bc.z.vid() + 1];
+    }
+    // Prefix sum -> CSR offsets.
+    for(int v = 1; v <= num_vars; ++v) wac3_adj_off[v] += wac3_adj_off[v - 1];
+    // Pass 2: scatter. Use a transient cursor (re-uses adj_off as scratch).
+    // The pragma suppresses a gcc-14 false positive in -Wstringop-overflow:
+    // the compiler fuses the vector's placement-new loop into a bulk memset
+    // and can't prove `num_vars * sizeof(int)` is bounded (it comes through
+    // a function call). num_vars is always >= 0 by construction.
+    #pragma GCC diagnostic push
+    #pragma GCC diagnostic ignored "-Wstringop-overflow"
+    bt::vector<int, ConcurrentAllocator> cursor(num_vars, ConcurrentAllocator{});
+    #pragma GCC diagnostic pop
+    for(int v = 0; v < num_vars; ++v) cursor[v] = wac3_adj_off[v];
+    for(int i = 0; i < num_bc; ++i) {
+      auto bc = root.iprop->load_deduce(i);
+      wac3_adj_bc[cursor[bc.x.vid()]++] = i;
+      wac3_adj_bc[cursor[bc.y.vid()]++] = i;
+      wac3_adj_bc[cursor[bc.z.vid()]++] = i;
+    }
+  }
+
+  /** Build the variable -> incident-TILE CSR for WWAC3.
+   *
+   * Same two-pass structure as `build_wac3_adjacency`, but the incidence unit
+   * is a tile of 32 consecutive bytecodes and a variable is counted at most
+   * ONCE per tile (per-tile dedup via the `seen[]` last-tile marker), so a tile
+   * appears in a var's list once no matter how many of the tile's bytecodes
+   * reference that var.
+   */
+  void build_wwac3_adjacency() {
+    const int num_vars  = root.store->vars();
+    const int num_bc    = root.iprop->num_deductions();
+    const int TILE      = 32;
+    const int num_tiles = (num_bc + TILE - 1) / TILE;
+    wwac3_vt_off.resize(num_vars + 1);
+    for(int v = 0; v <= num_vars; ++v) wwac3_vt_off[v] = 0;
+    #pragma GCC diagnostic push
+    #pragma GCC diagnostic ignored "-Wstringop-overflow"
+    bt::vector<int, ConcurrentAllocator> seen(num_vars, ConcurrentAllocator{});
+    #pragma GCC diagnostic pop
+    for(int v = 0; v < num_vars; ++v) seen[v] = -1;   // last tile that saw var v
+    // Pass 1: per-tile-deduped degree count (shifted by 1 for the prefix-sum).
+    for(int t = 0; t < num_tiles; ++t) {
+      const int lo = t * TILE;
+      const int hi = (lo + TILE < num_bc) ? (lo + TILE) : num_bc;
+      for(int b = lo; b < hi; ++b) {
+        auto bc = root.iprop->load_deduce(b);
+        const int vs[3] = { bc.x.vid(), bc.y.vid(), bc.z.vid() };
+        for(int a = 0; a < 3; ++a) {
+          const int v = vs[a];
+          if(seen[v] != t) { seen[v] = t; ++wwac3_vt_off[v + 1]; }
+        }
+      }
+    }
+    for(int v = 1; v <= num_vars; ++v) wwac3_vt_off[v] += wwac3_vt_off[v - 1];
+    wwac3_vt.resize(wwac3_vt_off[num_vars]);
+    #pragma GCC diagnostic push
+    #pragma GCC diagnostic ignored "-Wstringop-overflow"
+    bt::vector<int, ConcurrentAllocator> cursor(num_vars, ConcurrentAllocator{});
+    #pragma GCC diagnostic pop
+    for(int v = 0; v < num_vars; ++v) { cursor[v] = wwac3_vt_off[v]; seen[v] = -1; }
+    // Pass 2: scatter (same per-tile dedup).
+    for(int t = 0; t < num_tiles; ++t) {
+      const int lo = t * TILE;
+      const int hi = (lo + TILE < num_bc) ? (lo + TILE) : num_bc;
+      for(int b = lo; b < hi; ++b) {
+        auto bc = root.iprop->load_deduce(b);
+        const int vs[3] = { bc.x.vid(), bc.y.vid(), bc.z.vid() };
+        for(int a = 0; a < 3; ++a) {
+          const int v = vs[a];
+          if(seen[v] != t) { seen[v] = t; wwac3_vt[cursor[v]++] = t; }
+        }
+      }
+    }
   }
 };
 
@@ -134,6 +275,27 @@ struct BlockData {
   /** The decision taken when exploring the tree. */
   bt::vector<LightBranch<Itv>, bt::global_allocator> decisions;
 
+  /** Per-block scratch for the WAC3 fixpoint strategy (event-driven AC3
+   * worklist). Only allocated when `config.fixpoint == FixpointKind::WAC3`;
+   * empty otherwise. See `wac3_fixpoint` in `lala-core/include/lala/wac3_fixpoint.hpp`
+   * (added in Step 4) for the access pattern.
+   *
+   *   `wac3_frontier_a/b` (size num_bytecodes): double-buffered worklist of
+   *     bytecode indices to process. The kernel swaps `cur`/`nxt` each round.
+   *   `wac3_in_next` (size num_bytecodes): dedup flag, `1` iff a bytecode is
+   *     already in the next-round worklist. Zero-initialized; kept clean by
+   *     the algorithm at convergence so no per-rep reset is needed.
+   *   `wac3_var_dirty` (size num_vars): in-list marker for the dirty-var
+   *     scratch. Zero-initialized; kept clean by the algorithm.
+   *   `wac3_dirty_list` (size num_vars): dense list of variables narrowed
+   *     this round; used to build the next frontier via the CSR adjacency.
+   */
+  bt::vector<int, bt::global_allocator> wac3_frontier_a;
+  bt::vector<int, bt::global_allocator> wac3_frontier_b;
+  bt::vector<int, bt::global_allocator> wac3_in_next;
+  bt::vector<int, bt::global_allocator> wac3_var_dirty;
+  bt::vector<int, bt::global_allocator> wac3_dirty_list;
+
   /** Current depth of the search tree. */
   int depth;
 
@@ -167,6 +329,25 @@ struct BlockData {
       best_store = bt::make_shared<VStore<Itv, bt::global_allocator>, bt::global_allocator>(u_store);
       store = bt::allocate_shared<IStore, bt::pool_allocator>(store_allocator, u_store, store_allocator);
       iprop = bt::allocate_shared<IProp, bt::pool_allocator>(prop_allocator, u_iprop, store, prop_allocator);
+
+      // WAC3 per-block scratch. Sized from the just-allocated iprop/store.
+      // resize() value-initializes to zero, which is precisely what
+      // `wac3_in_next` and `wac3_var_dirty` need (the kernel relies on these
+      // being all-zero on entry and keeps them clean at convergence).
+      // WWAC3 reuses these buffers at TILE granularity: a tile id is in
+      // [0, ceil(num_bc/32)) <= num_bc, so the bytecode-sized frontier/in_next
+      // buffers are big enough (only the leading num_tiles entries are used).
+      if(unified_data.root.config.fixpoint == FixpointKind::WAC3
+      || unified_data.root.config.fixpoint == FixpointKind::WWAC3
+      || unified_data.root.config.fixpoint == FixpointKind::AWWAC3) {
+        const int num_bc   = iprop->num_deductions();
+        const int num_vars = store->vars();
+        wac3_frontier_a.resize(num_bc);
+        wac3_frontier_b.resize(num_bc);
+        wac3_in_next.resize(num_bc);
+        wac3_var_dirty.resize(num_vars);
+        wac3_dirty_list.resize(num_vars);
+      }
     }
   }
 
@@ -617,7 +798,8 @@ __global__ void initialize_global_data(
     block_data.timer = block_data.stats.stop_timer(Timer::KIND, block_data.timer); \
   }
 
-__global__ void gpu_barebones_solve(UnifiedData* unified_data, GridData* grid_data) {
+
+  __global__ __launch_bounds__(CUDA_THREADS_PER_BLOCK, 2) void gpu_barebones_solve(UnifiedData* unified_data, GridData* grid_data) {
   extern __shared__ unsigned char shared_mem[];
   auto& config = unified_data->root.config;
   BlockData& block_data = grid_data->blocks[blockIdx.x];
@@ -959,6 +1141,45 @@ __device__ INLINE void propagate(UnifiedData& unified_data, GridData& grid_data,
             block_data.stats.num_deductions += warp_iterations[i] * 32;
           }
         }
+      }
+      break;
+    }
+    case FixpointKind::WAC3:
+    case FixpointKind::WWAC3: {
+      // Warp-TILE-granular event-driven AC3 worklist; see
+      // lala-core/include/lala/wwac3_fixpoint.hpp. The frontier unit is a tile
+      // of 32 consecutive bytecodes; the CSR is var->tile (built once in
+      // UnifiedData); it reuses WAC3's per-block scratch (tile counts <= bytecode
+      // counts). −12.3% geomean vs per-bytecode WAC3 in the standalone prototype.
+      __shared__ int wwac3_deduces;
+      if(threadIdx.x == 0) wwac3_deduces = 0;
+      __syncthreads();
+      if(config.fixpoint == FixpointKind::WAC3) {
+        fp_iterations = wac3_fixpoint<CUDA_THREADS_PER_BLOCK>(
+          iprop,
+          unified_data.wac3_adj_off.data(),
+          unified_data.wac3_adj_bc.data(),
+          block_data.wac3_frontier_a.data(),
+          block_data.wac3_frontier_b.data(),
+          block_data.wac3_in_next.data(),
+          block_data.wac3_var_dirty.data(),
+          block_data.wac3_dirty_list.data(),
+          &wwac3_deduces);
+      }
+      else {
+        fp_iterations = wwac3_fixpoint<CUDA_THREADS_PER_BLOCK>(
+          iprop,
+          unified_data.wwac3_vt_off.data(),
+          unified_data.wwac3_vt.data(),
+          block_data.wac3_frontier_a.data(),   // tile-id frontier buffer A
+          block_data.wac3_frontier_b.data(),   // tile-id frontier buffer B
+          block_data.wac3_in_next.data(),      // dedup over tiles
+          block_data.wac3_var_dirty.data(),
+          block_data.wac3_dirty_list.data(),
+          &wwac3_deduces);
+      }
+      if(threadIdx.x == 0) {
+        block_data.stats.num_deductions += wwac3_deduces;
       }
       break;
     }

--- a/include/barebones_dive_and_solve.hpp
+++ b/include/barebones_dive_and_solve.hpp
@@ -6,9 +6,9 @@
 #include "common_solving.hpp"
 #include "memory_gpu.hpp"
 #include "lala/light_branch.hpp"
+#include "lala/wac1_fixpoint.hpp"
 #include "lala/wac3_fixpoint.hpp"
 #include "lala/wwac3_fixpoint.hpp"
-#include "lala/awwac3_fixpoint.hpp"
 #include <mutex>
 #include <thread>
 #include <chrono>
@@ -113,9 +113,8 @@ struct UnifiedData {
     if(root.config.fixpoint == FixpointKind::WAC3) {
       build_wac3_adjacency();
     }
-    else if(root.config.fixpoint == FixpointKind::WWAC3
-         || root.config.fixpoint == FixpointKind::AWWAC3) {
-      build_wwac3_adjacency();  // var->TILE CSR shared by WWAC3 + async AWWAC3.
+    else if(root.config.fixpoint == FixpointKind::WWAC3) {
+      build_wwac3_adjacency();
     }
   }
 
@@ -338,8 +337,7 @@ struct BlockData {
       // [0, ceil(num_bc/32)) <= num_bc, so the bytecode-sized frontier/in_next
       // buffers are big enough (only the leading num_tiles entries are used).
       if(unified_data.root.config.fixpoint == FixpointKind::WAC3
-      || unified_data.root.config.fixpoint == FixpointKind::WWAC3
-      || unified_data.root.config.fixpoint == FixpointKind::AWWAC3) {
+      || unified_data.root.config.fixpoint == FixpointKind::WWAC3) {
         const int num_bc   = iprop->num_deductions();
         const int num_vars = store->vars();
         wac3_frontier_a.resize(num_bc);
@@ -580,7 +578,7 @@ struct BlockData {
     //   decisions[depth-1].ropes[0], decisions[depth-1].ropes[1]);
     // Reallocate decisions if needed.
     if(decisions.size() == depth) {
-      printf("resize to %d\n", (int)decisions.size() * 2);
+      // printf("resize to %d\n", (int)decisions.size() * 2);
       decisions.resize(decisions.size() * 2);
     }
   }
@@ -635,10 +633,10 @@ struct GridData {
 
 MemoryConfig configure_gpu_barebones(CP<Itv>&);
 __global__ void initialize_global_data(UnifiedData*, bt::unique_ptr<GridData, bt::global_allocator>*);
+template <FixpointKind FP>
 __global__ void gpu_barebones_solve(UnifiedData*, GridData*);
-template <class FPEngine>
-__device__ INLINE void propagate(UnifiedData& unified_data, GridData& grid_data, BlockData& block_data,
-   FPEngine& fp_engine, bool& stop, bool& has_changed, bool& is_leaf_node);
+template <FixpointKind FP>
+__device__ INLINE void propagate(UnifiedData& unified_data, GridData& grid_data, BlockData& block_data, bool& stop, bool& has_changed, bool& is_leaf_node);
 __global__ void reduce_blocks(UnifiedData*, GridData*);
 __global__ void deallocate_global_data(bt::unique_ptr<GridData, bt::global_allocator>*);
 
@@ -665,11 +663,21 @@ void barebones_dive_and_solve(const Configuration<battery::standard_allocator>& 
   /** We wait that either the solving is interrupted, or that all threads have finished. */
   /** Block the signal CTRL-C to notify the threads if we must exit. */
   block_signal_ctrlc();
-  gpu_barebones_solve
-    <<<static_cast<unsigned int>(cp.stats.num_blocks),
-      CUDA_THREADS_PER_BLOCK,
-      mem_config.shared_bytes>>>
-    (unified_data.get(), grid_data->get());
+  auto launch = [&](auto fp_kind) {
+    constexpr FixpointKind FP = decltype(fp_kind)::value;
+    gpu_barebones_solve<FP><<<static_cast<unsigned int>(cp.stats.num_blocks), CUDA_THREADS_PER_BLOCK, mem_config.shared_bytes>>>(unified_data.get(), grid_data->get());
+  };
+  switch(config.fixpoint) {
+    case FixpointKind::WAC1:
+      launch(std::integral_constant<FixpointKind, FixpointKind::WAC1>{});
+      break;
+    case FixpointKind::WAC3:
+      launch(std::integral_constant<FixpointKind, FixpointKind::WAC3>{});
+      break;
+    case FixpointKind::WWAC3:
+      launch(std::integral_constant<FixpointKind, FixpointKind::WWAC3>{});
+      break;
+  }
   auto now = std::chrono::steady_clock::now();
   int64_t time_to_kernel_start = std::chrono::duration_cast<std::chrono::nanoseconds>(now - start).count();
   bool interrupted = wait_solving_ends(unified_data->stop, unified_data->root, start);
@@ -707,12 +715,22 @@ void barebones_dive_and_solve(const Configuration<battery::standard_allocator>& 
  */
 MemoryConfig configure_gpu_barebones(CP<Itv>& cp) {
   auto& config = cp.config;
+  auto kernel_ptr = [&]() -> void* {
+    switch(config.fixpoint) {
+      case FixpointKind::WAC1:   return (void*) gpu_barebones_solve<FixpointKind::WAC1>;
+      case FixpointKind::WAC3:   return (void*) gpu_barebones_solve<FixpointKind::WAC3>;
+      case FixpointKind::WWAC3:  return (void*) gpu_barebones_solve<FixpointKind::WWAC3>;
+      default:
+        fprintf(stderr, "ERROR: fixpoint method is not supported on -arch barebones\n");
+        exit(EXIT_FAILURE);
+    }
+  }();
 
   /** I. Number of blocks per SM. */
   cudaDeviceProp deviceProp;
   cudaGetDeviceProperties(&deviceProp, 0);
   int max_block_per_sm;
-  cudaOccupancyMaxActiveBlocksPerMultiprocessor(&max_block_per_sm, (void*) gpu_barebones_solve, CUDA_THREADS_PER_BLOCK, 0);
+  cudaOccupancyMaxActiveBlocksPerMultiprocessor(&max_block_per_sm, kernel_ptr, CUDA_THREADS_PER_BLOCK, 0);
   if(cp.config.verbose_solving) {
     printf("%% max_blocks_per_sm=%d\n", max_block_per_sm);
   }
@@ -780,7 +798,7 @@ MemoryConfig configure_gpu_barebones(CP<Itv>& cp) {
     mem_config = MemoryConfig(store_bytes, iprop_bytes);
   }
   else {
-    mem_config = MemoryConfig((void*) gpu_barebones_solve, config.verbose_solving, blocks_per_sm, store_bytes, iprop_bytes);
+    mem_config = MemoryConfig(kernel_ptr, config.verbose_solving, blocks_per_sm, store_bytes, iprop_bytes);
   }
   mem_config.print_mzn_statistics(config, cp.stats);
   return mem_config;
@@ -798,8 +816,8 @@ __global__ void initialize_global_data(
     block_data.timer = block_data.stats.stop_timer(Timer::KIND, block_data.timer); \
   }
 
-
-  __global__ __launch_bounds__(CUDA_THREADS_PER_BLOCK, 2) void gpu_barebones_solve(UnifiedData* unified_data, GridData* grid_data) {
+template <FixpointKind FP>
+__global__ __launch_bounds__(CUDA_THREADS_PER_BLOCK, 2) void gpu_barebones_solve(UnifiedData* unified_data, GridData* grid_data) {
   extern __shared__ unsigned char shared_mem[];
   auto& config = unified_data->root.config;
   BlockData& block_data = grid_data->blocks[blockIdx.x];
@@ -812,12 +830,6 @@ __global__ void initialize_global_data(
   block_data.allocate(*unified_data, *grid_data, shared_mem);
   __syncthreads();
   IProp& iprop = *block_data.iprop;
-#ifdef TURBO_NO_ENTAILED_PROP_REMOVAL
-  __shared__ BlockAsynchronousFixpointGPU<true> fp_engine;
-#else
-  __shared__ FixpointSubsetGPU<BlockAsynchronousFixpointGPU<true>, bt::global_allocator, CUDA_THREADS_PER_BLOCK> fp_engine;
-  fp_engine.init(iprop.num_deductions());
-#endif
   /** This shared variable is necessary to avoid multiple threads to read into `unified_data.stop.test()`,
    * potentially reading different values and leading to deadlock. */
   __shared__ bool stop;
@@ -848,9 +860,6 @@ __global__ void initialize_global_data(
     block_data.next_unassigned_var = 0;
     block_data.depth = 0;
     unified_data->root.store->copy_to(group, *block_data.store);
-#ifndef TURBO_NO_ENTAILED_PROP_REMOVAL
-    fp_engine.reset(iprop.num_deductions());
-#endif
     __syncthreads();
 
     // D. Dive into the search tree until we reach the target subproblem.
@@ -862,7 +871,7 @@ __global__ void initialize_global_data(
     __syncthreads();
     while(remaining_depth > 0 && !is_leaf_node && !stop) {
       __syncthreads();
-      propagate(*unified_data, *grid_data, block_data, fp_engine, stop, has_changed, is_leaf_node);
+      propagate<FP>(*unified_data, *grid_data, block_data, stop, has_changed, is_leaf_node);
       __syncthreads();
       if(!is_leaf_node) {
         block_data.split(has_changed, grid_data->search_strategies);
@@ -957,7 +966,7 @@ __global__ void initialize_global_data(
         }
 
         // II. Propagate the current node.
-        propagate(*unified_data, *grid_data, block_data, fp_engine, stop, has_changed, is_leaf_node);
+        propagate<FP>(*unified_data, *grid_data, block_data, stop, has_changed, is_leaf_node);
         __syncthreads();
 
         // III. Branching
@@ -1005,9 +1014,6 @@ __global__ void initialize_global_data(
             break;
           }
           // Restore from root by copying the store and re-applying all decisions from root to block_data.depth-1.
-#ifndef TURBO_NO_ENTAILED_PROP_REMOVAL
-          fp_engine.reset(iprop.num_deductions());
-#endif
           block_data.root_store->copy_to(group, *block_data.store);
           // __syncthreads();
           // if(threadIdx.x == 0) {
@@ -1075,19 +1081,12 @@ __global__ void initialize_global_data(
     block_data.stats.cumulative_time_block = block_data.stats.timers.time_of(Timer::FIRST_BLOCK_IDLE);
   }
   __syncthreads();
-#ifndef TURBO_NO_ENTAILED_PROP_REMOVAL
-  fp_engine.destroy();
-#endif
   block_data.deallocate_shared_data();
   __syncthreads();
 }
-
-template <class FPEngine>
-__device__ INLINE void propagate(UnifiedData& unified_data, GridData& grid_data, BlockData& block_data,
-   FPEngine& fp_engine, bool& stop, bool& has_changed, bool& is_leaf_node)
+template <FixpointKind FP>
+__device__ INLINE void propagate(UnifiedData& unified_data, GridData& grid_data, BlockData& block_data, bool& stop, bool& has_changed, bool& is_leaf_node)
 {
-  __shared__ int warp_iterations[CUDA_THREADS_PER_BLOCK/32];
-  warp_iterations[threadIdx.x / 32] = 0;
   auto& config = unified_data.root.config;
   IProp& iprop = *block_data.iprop;
   auto group = cooperative_groups::this_thread_block();
@@ -1099,89 +1098,59 @@ __device__ INLINE void propagate(UnifiedData& unified_data, GridData& grid_data,
 
   // II. Compute the fixpoint of the current node.
   int fp_iterations;
-#ifdef TURBO_NO_ENTAILED_PROP_REMOVAL
   int num_active = iprop.num_deductions();
-#else
-  int num_active = fp_engine.num_active();
-#endif
-  switch(config.fixpoint) {
-    case FixpointKind::AC1: {
-      fp_iterations = fp_engine.fixpoint(
-#ifdef TURBO_NO_ENTAILED_PROP_REMOVAL
-        iprop.num_deductions(),
-#endif
-        [&](int i){ return iprop.deduce(i); },
-        [&](){ return iprop.is_bot(); });
-      if(threadIdx.x == 0) {
-        block_data.stats.num_deductions += fp_iterations * num_active;
-      }
-      break;
+  // switch(config.fixpoint) {
+    // case FixpointKind::AC1: {
+    //   fp_iterations = fp_engine.fixpoint(
+    //     iprop.num_deductions(),
+    //     [&](int i){ return iprop.deduce(i); },
+    //     [&](){ return iprop.is_bot(); });
+    //   if(threadIdx.x == 0) {
+    //     block_data.stats.num_deductions += fp_iterations * num_active;
+    //   }
+    //   break;
+    // }
+  if constexpr (FP == FixpointKind::WAC1) {
+    __shared__ int num_deduces;
+    if(threadIdx.x == 0) num_deduces = 0;
+    __syncthreads();
+    fp_iterations = wac1_fixpoint<CUDA_THREADS_PER_BLOCK>(iprop, &num_deduces);
+    if(threadIdx.x == 0) {
+      block_data.stats.num_deductions += num_deduces;
     }
-    case FixpointKind::WAC1: {
-      if(num_active <= config.wac1_threshold) {
-        fp_iterations = fp_engine.fixpoint(
-#ifdef TURBO_NO_ENTAILED_PROP_REMOVAL
-        iprop.num_deductions(),
-#endif
-          [&](int i){ return iprop.deduce(i); },
-          [&](){ return iprop.is_bot(); });
-        if(threadIdx.x == 0) {
-          block_data.stats.num_deductions += fp_iterations * num_active;
-        }
-      }
-      else {
-        fp_iterations = fp_engine.fixpoint(
-#ifdef TURBO_NO_ENTAILED_PROP_REMOVAL
-          iprop.num_deductions(),
-#endif
-          [&](int i){ return warp_fixpoint<CUDA_THREADS_PER_BLOCK>(iprop, i, warp_iterations); },
-          [&](){ return iprop.is_bot(); });
-        if(threadIdx.x == 0) {
-          for(int i = 0; i < CUDA_THREADS_PER_BLOCK/32; ++i) {
-            block_data.stats.num_deductions += warp_iterations[i] * 32;
-          }
-        }
-      }
-      break;
+  } else if constexpr (FP == FixpointKind::WAC3) {
+    __shared__ int num_deduces;
+    if(threadIdx.x == 0) num_deduces = 0;
+    __syncthreads();
+    fp_iterations = wac3_fixpoint<CUDA_THREADS_PER_BLOCK>(
+      iprop,
+      unified_data.wac3_adj_off.data(),
+      unified_data.wac3_adj_bc.data(),
+      block_data.wac3_frontier_a.data(),
+      block_data.wac3_frontier_b.data(),
+      block_data.wac3_in_next.data(),
+      block_data.wac3_var_dirty.data(),
+      block_data.wac3_dirty_list.data(),
+      &num_deduces);
+    if(threadIdx.x == 0) {
+      block_data.stats.num_deductions += num_deduces;
     }
-    case FixpointKind::WAC3:
-    case FixpointKind::WWAC3: {
-      // Warp-TILE-granular event-driven AC3 worklist; see
-      // lala-core/include/lala/wwac3_fixpoint.hpp. The frontier unit is a tile
-      // of 32 consecutive bytecodes; the CSR is var->tile (built once in
-      // UnifiedData); it reuses WAC3's per-block scratch (tile counts <= bytecode
-      // counts). −12.3% geomean vs per-bytecode WAC3 in the standalone prototype.
-      __shared__ int wwac3_deduces;
-      if(threadIdx.x == 0) wwac3_deduces = 0;
-      __syncthreads();
-      if(config.fixpoint == FixpointKind::WAC3) {
-        fp_iterations = wac3_fixpoint<CUDA_THREADS_PER_BLOCK>(
-          iprop,
-          unified_data.wac3_adj_off.data(),
-          unified_data.wac3_adj_bc.data(),
-          block_data.wac3_frontier_a.data(),
-          block_data.wac3_frontier_b.data(),
-          block_data.wac3_in_next.data(),
-          block_data.wac3_var_dirty.data(),
-          block_data.wac3_dirty_list.data(),
-          &wwac3_deduces);
-      }
-      else {
-        fp_iterations = wwac3_fixpoint<CUDA_THREADS_PER_BLOCK>(
-          iprop,
-          unified_data.wwac3_vt_off.data(),
-          unified_data.wwac3_vt.data(),
-          block_data.wac3_frontier_a.data(),   // tile-id frontier buffer A
-          block_data.wac3_frontier_b.data(),   // tile-id frontier buffer B
-          block_data.wac3_in_next.data(),      // dedup over tiles
-          block_data.wac3_var_dirty.data(),
-          block_data.wac3_dirty_list.data(),
-          &wwac3_deduces);
-      }
-      if(threadIdx.x == 0) {
-        block_data.stats.num_deductions += wwac3_deduces;
-      }
-      break;
+  } else if constexpr (FP == FixpointKind::WWAC3) {
+    __shared__ int num_deduces;
+    if(threadIdx.x == 0) num_deduces = 0;
+    __syncthreads();
+    fp_iterations = wwac3_fixpoint<CUDA_THREADS_PER_BLOCK>(
+      iprop,
+      unified_data.wwac3_vt_off.data(),
+      unified_data.wwac3_vt.data(),
+      block_data.wac3_frontier_a.data(),   // tile-id frontier buffer A
+      block_data.wac3_frontier_b.data(),   // tile-id frontier buffer B
+      block_data.wac3_in_next.data(),      // dedup over tiles
+      block_data.wac3_var_dirty.data(),
+      block_data.wac3_dirty_list.data(),
+      &num_deduces);
+    if(threadIdx.x == 0) {
+      block_data.stats.num_deductions += num_deduces;
     }
   }
   TIMEPOINT(FIXPOINT);
@@ -1189,7 +1158,6 @@ __device__ INLINE void propagate(UnifiedData& unified_data, GridData& grid_data,
   // III. Analyze the result of propagation
 
   if(!iprop.is_bot()) {
-#ifdef TURBO_NO_ENTAILED_PROP_REMOVAL
     if(threadIdx.x == 0) {
       has_changed = false;
     }
@@ -1201,10 +1169,6 @@ __device__ INLINE void propagate(UnifiedData& unified_data, GridData& grid_data,
     }
     __syncthreads();
     num_active = has_changed ? 1 : 0;
-#else
-    fp_engine.select([&](int i) { return !iprop.ask(i); });
-    num_active = fp_engine.num_active();
-#endif
     TIMEPOINT(SELECT_FP_FUNCTIONS);
     /** Whenever we reach a solution node, we must have a bound better than the best bound of the local block.
      * Note that it doesn't mean the best bound of the block must be the best bound of the grid.

--- a/include/common_solving.hpp
+++ b/include/common_solving.hpp
@@ -12,6 +12,8 @@
 
 #include "config.hpp"
 #include "statistics.hpp"
+#include "turbo_dumper.h"
+#include "turbo_tcn_json.h"
 
 #include "battery/utility.hpp"
 #include "battery/allocator.hpp"
@@ -460,7 +462,11 @@ public:
       exit(EXIT_FAILURE);
     }
     GaussSeidelIteration fp_engine;
-    fp_engine.fixpoint(iprop->num_deductions(), [&](size_t i) { return iprop->deduce(i); });
+    // Skip preprocess-time propagation when dumping a prototype fixture: we
+    // want a pre-fixpoint state so the prototype has real work to replay.
+    if(config.dump_fixture_path.size() == 0) {
+      fp_engine.fixpoint(iprop->num_deductions(), [&](size_t i) { return iprop->deduce(i); });
+    }
     /* We need to initialize the simplifier even if we don't simplify.
        This is because the simplifier equivalence classes is used in SolverOutput. */
     initialize_simplifier(f);
@@ -610,11 +616,20 @@ public:
     }
     stats.print_stat("abstract_domain", name_of_abstract_domain());
     stats.print_stat("entailed_prop_removal", name_of_entailed_removal());
-    auto max_var = find_maximize_var(*f_ptr);
-    if(max_var.has_value()) {
-      auto max_var_decl = find_existential_of(*f_ptr, max_var.value());
-      if(max_var_decl.has_value()) {
-        add_minimize_objective_var(*f_ptr, max_var_decl.value());
+    // When dumping a fixture for the propagation prototype, we want to capture
+    // the unpropagated state. Simplification bakes propagated bounds into the
+    // variable existentials, so a post-simplify dump replays as already-at-
+    // fixpoint and exercises none of the GPU kernel's propagation work.
+    if(config.dump_fixture_path.size() > 0) {
+      config.disable_simplify = true;
+    }
+    if(config.arch == Arch::BAREBONES) {
+      auto max_var = find_maximize_var(*f_ptr);
+      if(max_var.has_value()) {
+        auto max_var_decl = find_existential_of(*f_ptr, max_var.value());
+        if(max_var_decl.has_value()) {
+          add_minimize_objective_var(*f_ptr, max_var_decl.value());
+        }
       }
     }
   #ifdef TURBO_IPC_ABSTRACT_DOMAIN
@@ -634,6 +649,22 @@ public:
     stats.stop_timer(Timer::PREPROCESSING, start);
     stats.print_timing_stat("preprocessing_time", Timer::PREPROCESSING);
     stats.print_mzn_end_stats();
+    // Dump the post-preprocessed constraint network for the propagation
+    // prototype's agent loop, then exit. Gated by -dump-fixture <path>.
+    if(config.dump_fixture_path.size() > 0) {
+      turbo_dump_fixture(*this, std::string(config.dump_fixture_path.data()),
+                         /*captured_depth=*/0,
+                         /*threads_per_block=*/CUDA_THREADS_PER_BLOCK);
+      std::exit(0);
+    }
+    // Dump the post-preprocessed TCN as JSON for batched_ac_proto's AC-vs-BC
+    // measurement, then exit. Gated by -dump-tcn <path>. Kept POST-simplify
+    // (equivalence classes collapsed, useless vars removed) — the real network
+    // Turbo solves — per batched_ac_proto/plan.md T1.1.
+    if(config.dump_tcn_path.size() > 0) {
+      turbo_dump_tcn_json(*this, std::string(config.dump_tcn_path.data()));
+      std::exit(0);
+    }
   }
 
 private:

--- a/include/config.hpp
+++ b/include/config.hpp
@@ -21,7 +21,10 @@ enum class Arch {
 
 enum class FixpointKind {
   AC1,
-  WAC1
+  WAC1,
+  WAC3,
+  WWAC3,  // warp-tile-granular AC3 worklist; see lala-core/include/lala/wwac3_fixpoint.hpp
+  AWWAC3  // async (streaming) warp-tile AC3 worklist; see lala-core/include/lala/awwac3_fixpoint.hpp
 };
 
 enum class InputFormat {
@@ -57,6 +60,13 @@ struct Configuration {
   battery::string<allocator_type> problem_path;
   battery::string<allocator_type> version;
   battery::string<allocator_type> hardware;
+  // If non-empty, preprocess() will dump the post-preprocessed constraint
+  // network to this path (binary fixture format) and exit. Consumed by the
+  // propagation-prototype agent loop; see prototype/tools/turbo_dumper.h.
+  battery::string<allocator_type> dump_fixture_path;
+  // If non-empty, preprocess() also dumps the post-preprocessed TCN as JSON to
+  // this path (batched_ac_proto bridge schema) and exits. See turbo_tcn_json.h.
+  battery::string<allocator_type> dump_tcn_path;
 
   CUDA Configuration(const allocator_type& alloc = allocator_type{}):
     print_intermediate_solutions(false),
@@ -101,7 +111,9 @@ struct Configuration {
     eps_var_order("default", alloc),
     problem_path(alloc),
     version(alloc),
-    hardware(alloc)
+    hardware(alloc),
+    dump_fixture_path(alloc),
+    dump_tcn_path(alloc)
   {}
 
   Configuration(Configuration<allocator_type>&&) = default;
@@ -133,7 +145,9 @@ struct Configuration {
     eps_value_order(other.eps_value_order, alloc),
     problem_path(other.problem_path, alloc),
     version(other.version, alloc),
-    hardware(other.hardware, alloc)
+    hardware(other.hardware, alloc),
+    dump_fixture_path(other.dump_fixture_path, alloc),
+    dump_tcn_path(other.dump_tcn_path, alloc)
   {}
 
   template <class Alloc2>
@@ -163,6 +177,8 @@ struct Configuration {
     problem_path = other.problem_path;
     version = other.version;
     hardware = other.hardware;
+    dump_fixture_path = other.dump_fixture_path;
+    dump_tcn_path = other.dump_tcn_path;
   }
 
   CUDA void print_commandline(const char* program_name) {
@@ -212,6 +228,12 @@ struct Configuration {
         return "ac1";
       case FixpointKind::WAC1:
         return "wac1";
+      case FixpointKind::WAC3:
+        return "wac3";
+      case FixpointKind::WWAC3:
+        return "wwac3";
+      case FixpointKind::AWWAC3:
+        return "awwac3";
       default:
         assert(0);
         return "Unknown";

--- a/include/config.hpp
+++ b/include/config.hpp
@@ -23,8 +23,7 @@ enum class FixpointKind {
   AC1,
   WAC1,
   WAC3,
-  WWAC3,  // warp-tile-granular AC3 worklist; see lala-core/include/lala/wwac3_fixpoint.hpp
-  AWWAC3  // async (streaming) warp-tile AC3 worklist; see lala-core/include/lala/awwac3_fixpoint.hpp
+  WWAC3  // warp-tile-granular AC3 worklist; see lala-core/include/lala/wwac3_fixpoint.hpp
 };
 
 enum class InputFormat {
@@ -232,8 +231,6 @@ struct Configuration {
         return "wac3";
       case FixpointKind::WWAC3:
         return "wwac3";
-      case FixpointKind::AWWAC3:
-        return "awwac3";
       default:
         assert(0);
         return "Unknown";

--- a/include/turbo_dumper.h
+++ b/include/turbo_dumper.h
@@ -1,0 +1,156 @@
+// ============================================================================
+// turbo_dumper.h — Production-side fixture dumper for the propagation prototype.
+//
+// This header is meant to be DROPPED INTO TURBO (e.g., copy it next to
+// barebones_dive_and_solve.hpp) and #included from common_solving.hpp's
+// preprocess(). It translates turbo's internal post-preprocess state into
+// the prototype's binary fixture format.
+//
+// Integration steps:
+//   1. Copy this header to turbo/include/.
+//   2. Add to turbo's Configuration:
+//        std::string dump_fixture_path;
+//   3. Add CLI flag parsing for --dump-fixture <path>.
+//   4. In common_solving.hpp's preprocess(), after the existing
+//      preprocess_tcn / preprocess_ipc call returns, add:
+//
+//        if(!config.dump_fixture_path.empty()) {
+//          turbo_dump_fixture(*this, config.dump_fixture_path);
+//          std::exit(0);  // exit after dump; agent loop uses the fixture
+//        }
+//
+// The dumper writes the SAME binary format documented in
+// prototype/include/proto_fixture.h. The prototype reads it back unchanged.
+//
+// Op translation:
+//   Turbo's bytecodes use lala::Sig (enum in lala/logic/ast.hpp). The
+//   prototype's Op enum is a subset. Unsupported Sig values cause the dumper
+//   to abort with a clear error message — so coverage gaps surface early
+//   rather than silently producing wrong fixtures.
+// ============================================================================
+#ifndef TURBO_DUMPER_H
+#define TURBO_DUMPER_H
+
+#include <cstdint>
+#include <cstdio>
+#include <stdexcept>
+#include <string>
+
+#include "lala/logic/ast.hpp"   // for lala::Sig
+
+namespace turbo_dumper_detail {
+
+// Match the prototype's enum byte values verbatim.
+enum ProtoOp : int32_t {
+  P_ADD = 0, P_SUB = 1, P_MUL = 2,
+  P_TDIV = 3, P_CDIV = 4, P_FDIV = 5, P_EDIV = 6,
+  P_MIN = 7, P_MAX = 8, P_EQ = 9, P_LEQ = 10,
+};
+
+// Translate lala::Sig → prototype Op. Throws on unsupported.
+inline ProtoOp translate_op(lala::Sig sig, int constraint_index) {
+  switch(sig) {
+    case lala::ADD:  return P_ADD;
+    case lala::SUB:  return P_SUB;
+    case lala::MUL:  return P_MUL;
+    case lala::TDIV: return P_TDIV;
+    case lala::CDIV: return P_CDIV;
+    case lala::FDIV: return P_FDIV;
+    case lala::EDIV: return P_EDIV;
+    case lala::MIN:  return P_MIN;
+    case lala::MAX:  return P_MAX;
+    case lala::EQ:   return P_EQ;
+    case lala::LEQ:  return P_LEQ;
+    default:
+      throw std::runtime_error(
+        "turbo_dumper: unsupported Sig " + std::to_string((int)sig) +
+        " at constraint " + std::to_string(constraint_index) +
+        ". Extend prototype/include/proto_types.h::Op to cover it.");
+  }
+}
+
+#pragma pack(push, 1)
+struct ProtoHeader {
+  uint32_t magic;            // 'PROP' little-endian
+  uint32_t version;
+  int32_t  num_vars;
+  int32_t  num_bytecodes;
+  int32_t  captured_depth;
+  int32_t  threads_per_block;
+  int32_t  reserved[2];
+};
+static_assert(sizeof(ProtoHeader) == 32, "header layout drift");
+
+struct ProtoItv {
+  int32_t lb;
+  int32_t ub;
+};
+
+struct ProtoBytecode {
+  int32_t op;
+  int32_t x;
+  int32_t y;
+  int32_t z;
+};
+#pragma pack(pop)
+
+} // namespace turbo_dumper_detail
+
+// Dump a fixture for the prototype.
+//
+// `cp` is turbo's AbstractDomains instance (CP<Itv>). At call time, cp.store
+// must hold the initial intervals and cp.iprop->bytecodes must hold the
+// constraint network — i.e., this should be called AFTER preprocess_tcn
+// has populated them.
+//
+// `captured_depth` defaults to 0 (root). To capture mid-dive fixtures, run
+// the solver to the desired depth before calling.
+template<class CP>
+inline void turbo_dump_fixture(const CP& cp, const std::string& path,
+                               int captured_depth = 0,
+                               int threads_per_block = 256) {
+  using namespace turbo_dumper_detail;
+
+  const auto& store = *cp.store;
+  const auto& iprop = *cp.iprop;
+  const int num_vars       = store.vars();
+  const int num_bytecodes  = iprop.num_deductions();
+
+  std::FILE* f = std::fopen(path.c_str(), "wb");
+  if(!f) throw std::runtime_error("turbo_dumper: cannot open " + path);
+
+  ProtoHeader h{};
+  h.magic              = 0x50524F50;  // 'PROP'
+  h.version            = 1;
+  h.num_vars           = num_vars;
+  h.num_bytecodes      = num_bytecodes;
+  h.captured_depth     = captured_depth;
+  h.threads_per_block  = threads_per_block;
+  std::fwrite(&h, sizeof(h), 1, f);
+
+  // Store: project each variable's interval.
+  for(int i = 0; i < num_vars; ++i) {
+    auto dom = store[i];
+    ProtoItv pitv;
+    pitv.lb = (int32_t)dom.lb().value();
+    pitv.ub = (int32_t)dom.ub().value();
+    std::fwrite(&pitv, sizeof(pitv), 1, f);
+  }
+
+  // Bytecodes: translate Sig and pack into the prototype's layout.
+  for(int i = 0; i < num_bytecodes; ++i) {
+    auto bc = iprop.load_deduce(i);
+    ProtoBytecode pbc;
+    pbc.op = (int32_t)translate_op(bc.op, i);
+    pbc.x  = bc.x.vid();
+    pbc.y  = bc.y.vid();
+    pbc.z  = bc.z.vid();
+    std::fwrite(&pbc, sizeof(pbc), 1, f);
+  }
+
+  std::fclose(f);
+  std::printf("[turbo_dumper] wrote fixture: %d vars, %d bytecodes, depth=%d → %s\n",
+              num_vars, num_bytecodes, captured_depth, path.c_str());
+}
+
+#endif // TURBO_DUMPER_H

--- a/include/turbo_tcn_json.h
+++ b/include/turbo_tcn_json.h
@@ -1,0 +1,116 @@
+// ============================================================================
+// turbo_tcn_json.h — dump the preprocessed TCN as batched_ac_proto JSON.
+//
+// Sibling of turbo_dumper.h (which writes the prototype's BINARY fixture). This
+// writes the JSON bridge schema consumed by batched_ac_proto/bp/problem.py
+// (load_json), for the AC-vs-BC decision-gate measurement (batched_ac_proto
+// plan.md T1.1):
+//
+//   {"variables":  [{"lb": 0, "ub": 7}, ...],
+//    "constraints":[{"op": "add", "x": 2, "y": 0, "z": 1}, ...]}
+//
+// Variable indices are the POST-preprocessing TCN variables; domains are the
+// preprocessed root domains (exactly what the histogram export in
+// common_solving.hpp iterates). Call AFTER preprocess_tcn has populated
+// store + iprop (same call site as turbo_dump_fixture).
+//
+// Op map (lala::Sig -> proto schema {add,mul,div,mod,min,max,eq,leq}):
+//   ADD->add  MUL->mul  MIN->min  MAX->max  EQ->eq  LEQ->leq
+//   TDIV/CDIV/FDIV/EDIV->div   (proto accepts then rejects div/mod at compile,
+//                               loudly — surfaces coverage gaps, per its README)
+//   SUB(x=y-z) is rewritten to add as y=x+z (the proto schema has no sub).
+// Any other Sig aborts with a clear message rather than emitting a wrong model.
+// ============================================================================
+#ifndef TURBO_TCN_JSON_H
+#define TURBO_TCN_JSON_H
+
+#include <cstdio>
+#include <stdexcept>
+#include <string>
+
+#include "lala/logic/ast.hpp"        // for lala::Sig
+#include "lala/split_strategy.hpp"   // for VariableOrder/ValueOrder + string_of_*
+
+template<class CP>
+inline void turbo_dump_tcn_json(const CP& cp, const std::string& path) {
+  const auto& store = *cp.store;
+  const auto& iprop = *cp.iprop;
+  const int num_vars = store.vars();
+  const int num_bc   = iprop.num_deductions();
+
+  std::FILE* f = std::fopen(path.c_str(), "w");
+  if(!f) throw std::runtime_error("turbo_tcn_json: cannot open " + path);
+
+  std::fputs("{\"variables\":[", f);
+  for(int i = 0; i < num_vars; ++i) {
+    auto dom = store[i];
+    std::fprintf(f, "%s{\"lb\":%lld,\"ub\":%lld}", (i ? "," : ""),
+                 (long long)dom.lb().value(), (long long)dom.ub().value());
+  }
+  std::fputs("],\"constraints\":[", f);
+
+  bool first = true;
+  for(int i = 0; i < num_bc; ++i) {
+    auto bc = iprop.load_deduce(i);
+    int x = bc.x.vid(), y = bc.y.vid(), z = bc.z.vid();
+    const char* op;
+    switch(bc.op) {
+      case lala::ADD:  op = "add"; break;
+      case lala::MUL:  op = "mul"; break;
+      case lala::MIN:  op = "min"; break;
+      case lala::MAX:  op = "max"; break;
+      case lala::EQ:   op = "eq";  break;
+      case lala::LEQ:  op = "leq"; break;
+      case lala::TDIV:
+      case lala::CDIV:
+      case lala::FDIV:
+      case lala::EDIV: op = "div"; break;
+      case lala::SUB:  op = "add"; { int t = x; x = y; y = t; } break; // x=y-z <=> y=x+z
+      default:
+        std::fclose(f);
+        throw std::runtime_error(
+          "turbo_tcn_json: unsupported Sig " + std::to_string((int)bc.op) +
+          " at constraint " + std::to_string(i) +
+          " (extend the op map / proto schema)");
+    }
+    std::fprintf(f, "%s{\"op\":\"%s\",\"x\":%d,\"y\":%d,\"z\":%d}",
+                 (first ? "" : ","), op, x, y, z);
+    first = false;
+  }
+  std::fputs("]", f);   // close "constraints"
+
+  // Objective: Turbo rewrites maximize into minimize (negating the var), so the
+  // direction is always "min" on minimize_obj_var. Absent for satisfaction
+  // problems. The prototype pins this var's upper bound to a fixed value to make
+  // the search FAIL (the gate measures BC-vs-AC fails), standing in for B&B.
+  if(!cp.minimize_obj_var.is_untyped()) {
+    std::fprintf(f, ",\"objective\":{\"var\":%d,\"dir\":\"min\"}",
+                 cp.minimize_obj_var.vid());
+  }
+
+  // Search strategies from the FZN annotation (var order, value order, var list)
+  // so the prototype branches the same way Turbo does. Empty "vars" => split on
+  // the whole store. (May include Turbo's EPS strategy first; the prototype uses
+  // the FZN search strategies that follow.)
+  std::fputs(",\"search\":[", f);
+  const auto& strats = cp.split->strategies_();
+  for(size_t s = 0; s < strats.size(); ++s) {
+    const auto& st = strats[s];
+    std::fprintf(f, "%s{\"var_order\":\"%s\",\"val_order\":\"%s\",\"vars\":[",
+                 (s ? "," : ""),
+                 lala::string_of_variable_order(st.var_order),
+                 lala::string_of_value_order(st.val_order));
+    for(size_t i = 0; i < st.vars.size(); ++i)
+      std::fprintf(f, "%s%d", (i ? "," : ""), st.vars[i].vid());
+    std::fputs("]}", f);
+  }
+  std::fputs("]}\n", f);
+
+  std::fclose(f);
+  std::printf("[turbo_tcn_json] wrote TCN: %d vars, %d constraints, obj_var=%d -> %s\n",
+              num_vars, num_bc,
+              cp.minimize_obj_var.is_untyped() ? -1 : cp.minimize_obj_var.vid(),
+              path.c_str());
+}
+
+#endif // TURBO_TCN_JSON_H

--- a/src/config.cpp
+++ b/src/config.cpp
@@ -9,7 +9,7 @@
 #include <algorithm>
 
 void usage_and_exit(const std::string& program_name) {
-  std::cout << "usage: " << program_name << " [-t 2000] [-a] [-n 10] [-i] [-f] [-s] [-v] [-p <i>] [-arch <cpu|hybrid|gpu|barebones>] [-p 48] [-or 48] [-sub 12] [-stack 100] [-fp <ac1|wac1>] [-wac1_threshold 0] [-eps_var_order <input_order|first_fail|anti_first_fail|smallest|largest>] [-eps_value_order <min|max|split|reverse_split>] [-seed 0] [-network_analysis] [-cutnodes 0] [-disable_simplify] [-force_ternarize] [-globalmem] [-version 1.0.0] [xcsp3instance.xml | fzninstance.fzn]" << std::endl;
+  std::cout << "usage: " << program_name << " [-t 2000] [-a] [-n 10] [-i] [-f] [-s] [-v] [-p <i>] [-arch <cpu|hybrid|gpu|barebones>] [-p 48] [-or 48] [-sub 12] [-stack 100] [-fp <ac1|wac1|wac3|wwac3|awwac3>] [-wac1_threshold 0] [-eps_var_order <input_order|first_fail|anti_first_fail|smallest|largest>] [-eps_value_order <min|max|split|reverse_split>] [-seed 0] [-network_analysis] [-cutnodes 0] [-disable_simplify] [-force_ternarize] [-globalmem] [-version 1.0.0] [xcsp3instance.xml | fzninstance.fzn]" << std::endl;
   std::cout << "\t-t 2000: Run the solver with a timeout of 2000 milliseconds." << std::endl;
   std::cout << "\t-timeout 2000: Same as -t, but if both -t and -timeout are specified, -timeout overrides -t." << std::endl;
   std::cout << "\t-a: Instructs the solver to report all solutions in the case of satisfaction problems, or print intermediate solutions of increasing quality in the case of optimisation problems." << std::endl;
@@ -21,9 +21,12 @@ void usage_and_exit(const std::string& program_name) {
   std::cout << "\t-ast: Print the AST of the model (useful to debug)." << std::endl;
   std::cout << "\t-p 48: On CPU, multithreading is not yet implemented. On GPU, equivalent to `-or 48`." << std::endl;
   std::cout << "\t-arch <cpu|gpu|hybrid|barebones>: Choose the architecture on which the problem will be solved." << std::endl;
-  std::cout << "\t-fp <ac1|wac1>: Choose the fixpoint strategy (default: ac1 on CPU, wac1 on GPU):" << std::endl;
+  std::cout << "\t-fp <ac1|wac1|wac3|wwac3|awwac3>: Choose the fixpoint strategy (default: ac1 on CPU, wac1 on GPU):" << std::endl;
   std::cout << "\t\t ac1: All propagators are executed in parallel at each iteration." << std::endl;
   std::cout << "\t\t wac1: Behave as ac1 when the number of active propagators is less than wac1_threshold. Otherwise,  each warp must reach a local fixpoint before executing the next 32 propagators (not compatible with -arch cpu)." << std::endl;
+  std::cout << "\t\t wac3: Level-synchronized wavefront AC3 (event-driven worklist). Maintains a frontier of propagators to (re)visit; only propagators incident to a narrowed variable get re-enqueued. Wins on wide/shallow constraint graphs; loses to wac1 on small + deep/tight networks. Not compatible with -arch cpu." << std::endl;
+  std::cout << "\t\t wwac3: WAC3 at warp-tile granularity. The frontier unit is a tile of 32 consecutive propagators processed in parallel by one warp; the worklist re-enqueues incident TILES of narrowed variables. Wins on deep/large networks (the warp-parallel tile processing latency-hides the over-approximation); loses on tiny ones. Not compatible with -arch cpu." << std::endl;
+  std::cout << "\t\t awwac3: ASYNC (streaming) wwac3. The BSP round barriers are replaced by a lock-free ring drained by persistent warps (no per-round __syncthreads). Wins further on deep/many-round networks by removing the per-round barrier. Not compatible with -arch cpu." << std::endl;
   std::cout << "\t-wac1_threshold 4096: Threshold below which we select AC1 instead of WAC1 (default: 0)." << std::endl;
   std::cout << "\t-or 48: Run the subproblems on 48 streaming multiprocessors (SMs) (only for GPU architecture). Default: -or 0 for automatic selection of the number of SMs." << std::endl;
   std::cout << "\t-sub 12: Create 2^12 subproblems to be solved in turns by the blocks (embarrasingly parallel search). The special value `-1` leaves Turbo to decide on the number of subproblems (at least 30 * number of blocks). Default: -sub -1." << std::endl;
@@ -40,6 +43,7 @@ void usage_and_exit(const std::string& program_name) {
   std::cout << "\t-force_ternarize: Force the transformation of the formula in ternary normal form, even with IPC abstract domain (note that it is enabled by default with PIR abstract domain)." << std::endl;
   std::cout << "\t-disable_simplify: Disable the simplification step." << std::endl;
   std::cout << "\t-globalmem: Store all data abstract elements in the global memory and do not try to optimise using shared memory." << std::endl;
+  std::cout << "\t-dump-fixture <path>: After preprocessing, dump the constraint network in binary fixture format to <path> and exit. Consumed by the propagation-prototype agent loop." << std::endl;
   exit(EXIT_FAILURE);
 }
 
@@ -187,12 +191,29 @@ Configuration<battery::standard_allocator> parse_args(int argc, char** argv) {
     else if(fixpoint == "wac1") {
       config.fixpoint = FixpointKind::WAC1;
     }
+    else if(fixpoint == "wac3") {
+      config.fixpoint = FixpointKind::WAC3;
+    }
+    else if(fixpoint == "wwac3") {
+      config.fixpoint = FixpointKind::WWAC3;
+    }
+    else if(fixpoint == "awwac3") {
+      config.fixpoint = FixpointKind::AWWAC3;
+    }
     else {
       std::cerr << "Unknown fixpoint -fp " << fixpoint << std::endl;
       exit(EXIT_FAILURE);
     }
   }
   input.read_size_t("-wac1_threshold", config.wac1_threshold);
+  std::string dump_fixture;
+  if(input.read_string("-dump-fixture", dump_fixture)) {
+    config.dump_fixture_path = battery::string<battery::standard_allocator>(dump_fixture.data());
+  }
+  std::string dump_tcn;
+  if(input.read_string("-dump-tcn", dump_tcn)) {
+    config.dump_tcn_path = battery::string<battery::standard_allocator>(dump_tcn.data());
+  }
   std::string eps_var_order;
   if(input.read_string("-eps_var_order", eps_var_order)) {
     config.eps_var_order = battery::string<battery::standard_allocator>(eps_var_order.data());

--- a/src/config.cpp
+++ b/src/config.cpp
@@ -9,7 +9,7 @@
 #include <algorithm>
 
 void usage_and_exit(const std::string& program_name) {
-  std::cout << "usage: " << program_name << " [-t 2000] [-a] [-n 10] [-i] [-f] [-s] [-v] [-p <i>] [-arch <cpu|hybrid|gpu|barebones>] [-p 48] [-or 48] [-sub 12] [-stack 100] [-fp <ac1|wac1|wac3|wwac3|awwac3>] [-wac1_threshold 0] [-eps_var_order <input_order|first_fail|anti_first_fail|smallest|largest>] [-eps_value_order <min|max|split|reverse_split>] [-seed 0] [-network_analysis] [-cutnodes 0] [-disable_simplify] [-force_ternarize] [-globalmem] [-version 1.0.0] [xcsp3instance.xml | fzninstance.fzn]" << std::endl;
+  std::cout << "usage: " << program_name << " [-t 2000] [-a] [-n 10] [-i] [-f] [-s] [-v] [-p <i>] [-arch <cpu|hybrid|gpu|barebones>] [-p 48] [-or 48] [-sub 12] [-stack 100] [-fp <ac1|wac1|wac3|wwac3>] [-wac1_threshold 0] [-eps_var_order <input_order|first_fail|anti_first_fail|smallest|largest>] [-eps_value_order <min|max|split|reverse_split>] [-seed 0] [-network_analysis] [-cutnodes 0] [-disable_simplify] [-force_ternarize] [-globalmem] [-version 1.0.0] [xcsp3instance.xml | fzninstance.fzn]" << std::endl;
   std::cout << "\t-t 2000: Run the solver with a timeout of 2000 milliseconds." << std::endl;
   std::cout << "\t-timeout 2000: Same as -t, but if both -t and -timeout are specified, -timeout overrides -t." << std::endl;
   std::cout << "\t-a: Instructs the solver to report all solutions in the case of satisfaction problems, or print intermediate solutions of increasing quality in the case of optimisation problems." << std::endl;
@@ -21,12 +21,11 @@ void usage_and_exit(const std::string& program_name) {
   std::cout << "\t-ast: Print the AST of the model (useful to debug)." << std::endl;
   std::cout << "\t-p 48: On CPU, multithreading is not yet implemented. On GPU, equivalent to `-or 48`." << std::endl;
   std::cout << "\t-arch <cpu|gpu|hybrid|barebones>: Choose the architecture on which the problem will be solved." << std::endl;
-  std::cout << "\t-fp <ac1|wac1|wac3|wwac3|awwac3>: Choose the fixpoint strategy (default: ac1 on CPU, wac1 on GPU):" << std::endl;
+  std::cout << "\t-fp <ac1|wac1|wac3|wwac3>: Choose the fixpoint strategy (default: ac1 on CPU, wac1 on GPU):" << std::endl;
   std::cout << "\t\t ac1: All propagators are executed in parallel at each iteration." << std::endl;
   std::cout << "\t\t wac1: Behave as ac1 when the number of active propagators is less than wac1_threshold. Otherwise,  each warp must reach a local fixpoint before executing the next 32 propagators (not compatible with -arch cpu)." << std::endl;
   std::cout << "\t\t wac3: Level-synchronized wavefront AC3 (event-driven worklist). Maintains a frontier of propagators to (re)visit; only propagators incident to a narrowed variable get re-enqueued. Wins on wide/shallow constraint graphs; loses to wac1 on small + deep/tight networks. Not compatible with -arch cpu." << std::endl;
   std::cout << "\t\t wwac3: WAC3 at warp-tile granularity. The frontier unit is a tile of 32 consecutive propagators processed in parallel by one warp; the worklist re-enqueues incident TILES of narrowed variables. Wins on deep/large networks (the warp-parallel tile processing latency-hides the over-approximation); loses on tiny ones. Not compatible with -arch cpu." << std::endl;
-  std::cout << "\t\t awwac3: ASYNC (streaming) wwac3. The BSP round barriers are replaced by a lock-free ring drained by persistent warps (no per-round __syncthreads). Wins further on deep/many-round networks by removing the per-round barrier. Not compatible with -arch cpu." << std::endl;
   std::cout << "\t-wac1_threshold 4096: Threshold below which we select AC1 instead of WAC1 (default: 0)." << std::endl;
   std::cout << "\t-or 48: Run the subproblems on 48 streaming multiprocessors (SMs) (only for GPU architecture). Default: -or 0 for automatic selection of the number of SMs." << std::endl;
   std::cout << "\t-sub 12: Create 2^12 subproblems to be solved in turns by the blocks (embarrasingly parallel search). The special value `-1` leaves Turbo to decide on the number of subproblems (at least 30 * number of blocks). Default: -sub -1." << std::endl;
@@ -196,9 +195,6 @@ Configuration<battery::standard_allocator> parse_args(int argc, char** argv) {
     }
     else if(fixpoint == "wwac3") {
       config.fixpoint = FixpointKind::WWAC3;
-    }
-    else if(fixpoint == "awwac3") {
-      config.fixpoint = FixpointKind::AWWAC3;
     }
     else {
       std::cerr << "Unknown fixpoint -fp " << fixpoint << std::endl;

--- a/src/turbo.cpp
+++ b/src/turbo.cpp
@@ -28,22 +28,19 @@ int main(int argc, char** argv) {
       config.print_commandline(argv[0]);
       printf("\"\n");
     }
-    if(config.arch == Arch::CPU) {
-      cpu_solve(config);
-    }
-#ifndef DISABLE_FULL_GPU_SOLVING
-    else if(config.arch == Arch::GPU) {
-      gpu_dive_and_solve(config);
-    }
-#endif
-    else if(config.arch == Arch::BAREBONES) {
+// #ifndef DISABLE_FULL_GPU_SOLVING
+//     else if(config.arch == Arch::GPU) {
+//       gpu_dive_and_solve(config);
+//     }
+// #endif
+    if(config.arch == Arch::BAREBONES) {
       barebones::barebones_dive_and_solve(config);
     }
-#ifndef DISABLE_HYBRID_GPU_SOLVING
-    else if(config.arch == Arch::HYBRID) {
-      hybrid_dive_and_solve(config);
-    }
-#endif
+// #ifndef DISABLE_HYBRID_GPU_SOLVING
+//     else if(config.arch == Arch::HYBRID) {
+//       hybrid_dive_and_solve(config);
+//     }
+// #endif
   }
   catch (std::exception &e)
   {


### PR DESCRIPTION
Implements two event-driven fixed-point algorithms, PEF and WPEF, described in my
master's thesis. The code is functional and has been evaluated on the MiniZinc
Challenge 2024 suite, but still needs some refactoring before review, so this is
opened as a draft.

Naming differs between the thesis and the code:

| thesis | `-fp` flag |
|--------|------------|
| WF     | `wac1`     |
| PEF    | `wac3`     |
| WPEF   | `wwac3`    |

### Companion changes

The algorithms also require changes in the following repositories, which will be submitted separately.

- [`lala-core`]([https://github.com/multivvac/lala-core])
- [`lala-pc`]([https://github.com/multivvac/lala-pc])

### Related pull requests

- [ ] `lala-core` — TODO
- [ ] `lala-pc` — TODO